### PR TITLE
feat: create store button and rename home button as profile in navbar

### DIFF
--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -13,16 +13,18 @@ const Navbar = ({handleClick, isLoggedIn}) => (
     <nav>
       {isLoggedIn ? (
         <div>
-          <CartIcon />
           {/* The navbar will show these links after you log in */}
-          <Link to="/home">Home</Link>
+          <Link to="/">Store</Link>
+          <Link to="/home">Profile</Link>
           <a href="#" onClick={handleClick}>
             Logout
           </a>
+          <CartIcon />
         </div>
       ) : (
         <div>
           {/* The navbar will show these links before you log in */}
+          <Link to="/">Store</Link>
           <Link to="/login">Login</Link>
           <Link to="/signup">Sign Up</Link>
           <div>

--- a/client/routes.js
+++ b/client/routes.js
@@ -23,7 +23,8 @@ class Routes extends Component {
   }
 
   render() {
-    const {isLoggedIn, isAdmin} = this.props
+    const {isLoggedIn} = this.props
+    const isAdmin = isLoggedIn ? this.props.isAdmin : false
 
     return (
       <Switch>
@@ -46,7 +47,7 @@ class Routes extends Component {
             )}
           </Switch>
         )}
-        {/* Displays our Login component as a fallback */}
+        {/* Displays allProducts component as a fallback */}
         <Route component={allProducts} />
       </Switch>
     )


### PR DESCRIPTION
I renamed the "home" button "Profile" since I thought "Home" was confusing.  

Added a new button "Store" that can get everyone (logged in or otherwise) to our main store page.
